### PR TITLE
Decouple finalization from retrieving the request

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "instant-acme"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Async pure-Rust ACME client"

--- a/examples/provision.rs
+++ b/examples/provision.rs
@@ -130,8 +130,15 @@ async fn main() -> anyhow::Result<()> {
 
     // Finalize the order and print certificate chain, private key and account credentials.
 
-    let cert_chain_pem = order.finalize(&csr).await.unwrap();
-    info!("certficate chain:\n\n{}", cert_chain_pem,);
+    order.finalize(&csr).await.unwrap();
+    let cert_chain_pem = loop {
+        match order.certificate().await.unwrap() {
+            Some(cert_chain_pem) => break cert_chain_pem,
+            None => sleep(Duration::from_secs(1)).await,
+        }
+    };
+
+    info!("certficate chain:\n\n{}", cert_chain_pem);
     info!("private key:\n\n{}", cert.serialize_private_key_pem());
     info!(
         "account credentials:\n\n{}",

--- a/src/types.rs
+++ b/src/types.rs
@@ -60,7 +60,7 @@ pub struct AccountCredentials<'a> {
 }
 
 /// An RFC 7807 problem document as returned by the ACME server
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Problem {
     /// One of an enumerated list of problem types


### PR DESCRIPTION
This should not require any extra requests in the case the order is `valid` immediately, as we've seen in the past, but allows the caller to check multiple times if the order takes more time to become valid.

Fixes #14.